### PR TITLE
feat: フィードバック付きembed送信機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,8 @@
 DISCORD_BOT_TOKEN=your-discord-bot-token-here
 DISCORD_CLIENT_ID=your-discord-client-id-here
 DISCORD_GUILD_ID=your-discord-guild-id-here
+DISCORD_TEXT_CHANNEL_ID=your-text-channel-id-here
+
+# Optional: Feedback timeout in milliseconds (e.g., 30000 for 30 seconds)
+# If not set, feedback will wait indefinitely
+# DISCORD_FEEDBACK_TIMEOUT=30000

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1,4 +1,15 @@
-import { Client, Events, GatewayIntentBits, type MessageCreateOptions, type TextBasedChannel } from "discord.js";
+import { 
+    Client, 
+    Events, 
+    GatewayIntentBits, 
+    type MessageCreateOptions, 
+    type TextBasedChannel,
+    ButtonBuilder,
+    ButtonStyle,
+    ActionRowBuilder,
+    type ButtonInteraction,
+    type Message
+} from "discord.js";
 import { logger } from "../utils/logger";
 
 /**
@@ -21,6 +32,10 @@ export class DiscordBot {
     private client: Client;
     private config: DiscordBotConfig;
     private isReady: boolean = false;
+    private feedbackResolvers: Map<string, {
+        resolve: (value: { response: 'yes' | 'no'; userId: string }) => void;
+        timeout?: NodeJS.Timeout;
+    }> = new Map();
 
     /**
      * コンストラクタ
@@ -49,6 +64,17 @@ export class DiscordBot {
 
         this.client.on(Events.Error, (error) => {
             logger.error("Discord client error:", error);
+        });
+
+        this.client.on(Events.InteractionCreate, async (interaction) => {
+            if (!interaction.isButton()) return;
+            
+            const buttonInteraction = interaction as ButtonInteraction;
+            const [action, messageId] = buttonInteraction.customId.split(':');
+            
+            if (action === 'feedback_yes' || action === 'feedback_no') {
+                await this.handleFeedbackInteraction(buttonInteraction, action, messageId);
+            }
         });
     }
 
@@ -126,5 +152,128 @@ export class DiscordBot {
      */
     _setReady(ready: boolean): void {
         this.isReady = ready;
+    }
+
+    /**
+     * フィードバック付きメッセージを送信
+     * @param content MessageCreateOptions（embedを含む）
+     * @param feedbackPrompt フィードバックプロンプト
+     * @param timeout タイムアウト時間（ミリ秒）
+     * @returns フィードバック結果
+     */
+    async sendMessageWithFeedback(
+        content: MessageCreateOptions,
+        feedbackPrompt: string = "Please select:",
+        timeout?: number
+    ): Promise<{ response: 'yes' | 'no' | 'timeout'; userId?: string; responseTime?: number }> {
+        const startTime = Date.now();
+        
+        const yesButton = new ButtonBuilder()
+            .setCustomId(`feedback_yes:${Date.now()}`)
+            .setLabel('Yes')
+            .setStyle(ButtonStyle.Success);
+
+        const noButton = new ButtonBuilder()
+            .setCustomId(`feedback_no:${Date.now()}`)
+            .setLabel('No')
+            .setStyle(ButtonStyle.Danger);
+
+        const row = new ActionRowBuilder<ButtonBuilder>()
+            .addComponents(yesButton, noButton);
+
+        const messageOptions: MessageCreateOptions = {
+            ...content,
+            content: feedbackPrompt,
+            components: [row]
+        };
+
+        const message = await this.sendMessageAndGetMessage(messageOptions);
+        const messageId = message.id;
+
+        return new Promise((resolve) => {
+            const timeoutHandle = timeout ? setTimeout(() => {
+                this.feedbackResolvers.delete(messageId);
+                resolve({ response: 'timeout', responseTime: Date.now() - startTime });
+            }, timeout) : undefined;
+
+            this.feedbackResolvers.set(messageId, {
+                resolve: (value) => {
+                    if (timeoutHandle) clearTimeout(timeoutHandle);
+                    this.feedbackResolvers.delete(messageId);
+                    resolve({ ...value, responseTime: Date.now() - startTime });
+                },
+                timeout: timeoutHandle
+            });
+        });
+    }
+
+    /**
+     * メッセージを送信してMessageオブジェクトを返す
+     * @private
+     * @param content 送信するメッセージ内容
+     * @returns 送信されたMessage
+     */
+    private async sendMessageAndGetMessage(content: string | MessageCreateOptions): Promise<Message> {
+        if (!this.isReady) {
+            throw new Error("Bot is not ready");
+        }
+
+        const channel = this.client.channels.cache.get(this.config.textChannelId);
+        
+        if (!channel) {
+            throw new Error("Channel not found");
+        }
+
+        if (!channel.isTextBased()) {
+            throw new Error("Channel is not a text channel");
+        }
+
+        try {
+            if ('send' in channel) {
+                return await channel.send(content);
+            } else {
+                throw new Error("Channel does not support sending messages");
+            }
+        } catch (error) {
+            logger.error("Failed to send message:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * フィードバックインタラクションを処理
+     * @private
+     * @param interaction ButtonInteraction
+     * @param action 'feedback_yes' または 'feedback_no'
+     * @param messageId メッセージID
+     */
+    private async handleFeedbackInteraction(
+        interaction: ButtonInteraction,
+        action: string,
+        messageId: string
+    ): Promise<void> {
+        try {
+            const resolver = this.feedbackResolvers.get(interaction.message.id);
+            if (resolver) {
+                const response = action === 'feedback_yes' ? 'yes' : 'no';
+                resolver.resolve({ response, userId: interaction.user.id });
+                
+                await interaction.reply({
+                    content: `Thank you for your feedback! You selected: ${response}`,
+                    ephemeral: true
+                });
+            } else {
+                await interaction.reply({
+                    content: 'This feedback session has expired.',
+                    ephemeral: true
+                });
+            }
+        } catch (error) {
+            logger.error("Error handling feedback interaction:", error);
+            await interaction.reply({
+                content: 'An error occurred while processing your feedback.',
+                ephemeral: true
+            }).catch(() => {});
+        }
     }
 }

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -27,3 +27,23 @@ export interface SendDiscordEmbedArgs {
         inline?: boolean;
     }>;
 }
+
+/**
+ * Discord フィードバック付き Embed 送信ツールの引数
+ */
+export interface SendDiscordEmbedWithFeedbackArgs {
+    /** Embed のタイトル */
+    title?: string;
+    /** Embed の説明 */
+    description?: string;
+    /** Embed の色（10進数） */
+    color?: number;
+    /** Embed のフィールド */
+    fields?: Array<{
+        name: string;
+        value: string;
+        inline?: boolean;
+    }>;
+    /** ボタンの上に表示するテキスト */
+    feedbackPrompt?: string;
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,6 +14,9 @@ export const env = parseEnv(process.env, {
     DISCORD_CLIENT_ID: z.string().min(1),
     DISCORD_GUILD_ID: z.string().min(1),
     DISCORD_TEXT_CHANNEL_ID: z.string().min(1),
+    DISCORD_FEEDBACK_TIMEOUT: z.string().optional().transform(val => 
+        val ? parseInt(val, 10) : undefined
+    ),
 });
 
 /**

--- a/tests/integration/discord-mcp.test.ts
+++ b/tests/integration/discord-mcp.test.ts
@@ -167,10 +167,11 @@ describe("Discord と MCP の統合テスト", () => {
             const tools = await (mcpServer as any).listTools();
 
             // 期待されるツールが含まれていることを確認
-            expect(tools.tools).toHaveLength(2);
+            expect(tools.tools).toHaveLength(3);
             expect(tools.tools.map((t: any) => t.name)).toEqual([
                 "send_discord_message",
-                "send_discord_embed"
+                "send_discord_embed",
+                "send_discord_embed_with_feedback"
             ]);
         });
     });


### PR DESCRIPTION
Submitted by Claude Code 🛠️

---

## 概要

Discord Interface MCPにフィードバック機能を追加しました。MCPクライアントがDiscordに送信したembedメッセージに対して、ユーザーからYes/Noのフィードバックを受け取れるようになります。

## 実装内容

### 🎯 新しいMCPツール
- `send_discord_embed_with_feedback`: embedメッセージとYes/Noボタンを送信し、ユーザーのフィードバックを待機

### 🤖 Discord Bot拡張 (`src/discord/bot.ts`)
- ButtonInteractionイベントハンドラーの追加
- フィードバック待機用のPromise管理システム
- `sendMessageWithFeedback`メソッドでボタン付きメッセージを送信

### 🔧 MCPサーバー拡張 (`src/mcp/server.ts`)
- 新しいツールの実装
- フィードバック結果をJSON形式で返却
- タイムアウト機能のサポート

### ⚙️ 環境変数 (`src/utils/env.ts`)
- `DISCORD_FEEDBACK_TIMEOUT`: フィードバックのタイムアウト時間（ミリ秒）
- 未設定時は無限待機（デフォルト動作）

### 📝 型定義 (`src/types/mcp.ts`)
- `SendDiscordEmbedWithFeedbackArgs`: 新ツールの引数型を追加

## 動作フロー

1. MCPクライアントが`send_discord_embed_with_feedback`ツールを呼び出し
2. Discord BotがembedとYes/Noボタンを送信
3. MCPサーバーがユーザーのボタンクリックを待機
4. フィードバックを受け取ったら結果を返却
5. タイムアウト時は`response: 'timeout'`を返却

## テスト結果

```
✅ TypeScript型チェック: 成功
✅ ビルド: 成功 (dist/index.js)
```

🤖 Generated with [Claude Code](https://claude.ai/code)