### PR TITLE
feat: Discord Interface MCP の機能向上 - CSS色名、カスタムボタン、多言語対応

### DIFF
--- a/.claude-workspace/.gitkeep
+++ b/.claude-workspace/.gitkeep
@@ -1,1 +1,0 @@
-# This directory is used for Claude workspace files

--- a/scripts/test-mcp-tools-enhanced.js
+++ b/scripts/test-mcp-tools-enhanced.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+/**
+ * Enhanced MCP Tools Test Script
+ * Tests all available tools with comprehensive examples including multilingual support
+ */
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Test environment variables
+const testEnv = {
+    NODE_ENV: 'test',
+    DISCORD_BOT_TOKEN: 'test-token-for-mcp-inspector',
+    DISCORD_GUILD_ID: 'test-guild-123456',
+    DISCORD_TEXT_CHANNEL_ID: 'test-channel-789012'
+};
+
+// MCP requests to test
+const testRequests = [
+    {
+        name: "Initialize MCP Server",
+        request: {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+                protocolVersion: "2024-11-05",
+                capabilities: {
+                    tools: {}
+                },
+                clientInfo: {
+                    name: "mcp-inspector-test",
+                    version: "1.0.0"
+                }
+            }
+        }
+    },
+    {
+        name: "List Available Tools",
+        request: {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list"
+        }
+    },
+    {
+        name: "Test send_discord_embed with CSS Colors",
+        request: {
+            jsonrpc: "2.0",
+            id: 3,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed",
+                arguments: {
+                    title: "Color Test",
+                    description: "Testing CSS basic 16 colors",
+                    color: "red",
+                    fields: [
+                        { name: "Color", value: "red", inline: true },
+                        { name: "Hex Value", value: "#FF0000", inline: true }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        name: "Test send_discord_embed_with_feedback - Default Buttons",
+        request: {
+            jsonrpc: "2.0",
+            id: 4,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed_with_feedback",
+                arguments: {
+                    title: "Default Feedback Test",
+                    description: "Testing default Yes/No buttons",
+                    color: "blue",
+                    feedbackPrompt: "Do you agree with this test?"
+                }
+            }
+        }
+    },
+    {
+        name: "Test send_discord_embed_with_feedback - Custom English Buttons",
+        request: {
+            jsonrpc: "2.0",
+            id: 5,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed_with_feedback",
+                arguments: {
+                    title: "Custom Feedback Test",
+                    description: "Testing custom buttons",
+                    color: "green",
+                    feedbackPrompt: "How would you rate this service?",
+                    feedbackButtons: [
+                        { label: "Excellent", value: "excellent" },
+                        { label: "Good", value: "good" },
+                        { label: "Average", value: "average" },
+                        { label: "Poor", value: "poor" }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        name: "Test send_discord_embed_with_feedback - Multilingual Japanese",
+        request: {
+            jsonrpc: "2.0",
+            id: 6,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed_with_feedback",
+                arguments: {
+                    title: "多言語テスト",
+                    description: "日本語のフィードバックボタンをテストします",
+                    color: "purple",
+                    feedbackPrompt: "満足度をお聞かせください",
+                    feedbackButtons: [
+                        { label: "とても満足", value: "とても満足" },
+                        { label: "満足", value: "満足" },
+                        { label: "普通", value: "普通" },
+                        { label: "不満", value: "不満" }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        name: "Test send_discord_embed_with_feedback - Emoji Buttons",
+        request: {
+            jsonrpc: "2.0",
+            id: 7,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed_with_feedback",
+                arguments: {
+                    title: "Emoji Feedback Test",
+                    description: "Testing emoji buttons",
+                    color: "yellow",
+                    feedbackPrompt: "How do you feel about this?",
+                    feedbackButtons: [
+                        { label: "😍 Love it!", value: "love" },
+                        { label: "👍 Like it", value: "like" },
+                        { label: "😐 Neutral", value: "neutral" },
+                        { label: "👎 Dislike", value: "dislike" },
+                        { label: "😢 Hate it", value: "hate" }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        name: "Test Invalid Color (Should Fail)",
+        request: {
+            jsonrpc: "2.0",
+            id: 8,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed",
+                arguments: {
+                    title: "Invalid Color Test",
+                    color: "orange" // Invalid CSS basic 16 color
+                }
+            }
+        }
+    },
+    {
+        name: "Test Too Many Buttons (Should Fail)",
+        request: {
+            jsonrpc: "2.0",
+            id: 9,
+            method: "tools/call",
+            params: {
+                name: "send_discord_embed_with_feedback",
+                arguments: {
+                    title: "Too Many Buttons Test",
+                    feedbackButtons: [
+                        { label: "1", value: "one" },
+                        { label: "2", value: "two" },
+                        { label: "3", value: "three" },
+                        { label: "4", value: "four" },
+                        { label: "5", value: "five" },
+                        { label: "6", value: "six" } // 6th button should fail
+                    ]
+                }
+            }
+        }
+    }
+];
+
+async function testMCPServer() {
+    console.log('🧪 Enhanced MCP Server Testing with MCP Inspector Compatibility');
+    console.log('======================================================\n');
+
+    const serverPath = path.join(__dirname, '..', 'dist', 'index.js');
+    
+    console.log(`📁 Server Path: ${serverPath}`);
+    console.log(`🌍 Environment Variables:`);
+    Object.entries(testEnv).forEach(([key, value]) => {
+        console.log(`   ${key}: ${value}`);
+    });
+    console.log('');
+
+    for (const test of testRequests) {
+        console.log(`🔍 Testing: ${test.name}`);
+        console.log(`📝 Request: ${JSON.stringify(test.request, null, 2)}`);
+        
+        try {
+            const result = await sendMCPRequest(serverPath, test.request, testEnv);
+            console.log(`✅ Response: ${JSON.stringify(result, null, 2)}`);
+        } catch (error) {
+            console.log(`❌ Error: ${error.message}`);
+        }
+        
+        console.log('─'.repeat(80));
+        console.log('');
+    }
+}
+
+function sendMCPRequest(serverPath, request, env) {
+    return new Promise((resolve, reject) => {
+        const child = spawn('node', [serverPath], {
+            env: { ...process.env, ...env },
+            stdio: ['pipe', 'pipe', 'pipe']
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let responseReceived = false;
+
+        const timeout = setTimeout(() => {
+            if (!responseReceived) {
+                child.kill();
+                reject(new Error('Request timeout'));
+            }
+        }, 5000);
+
+        child.stdout.on('data', (data) => {
+            stdout += data.toString();
+            
+            // Try to parse JSON response
+            const lines = stdout.split('\n');
+            for (const line of lines) {
+                if (line.trim()) {
+                    try {
+                        const response = JSON.parse(line);
+                        if (response.jsonrpc === "2.0" && response.id === request.id) {
+                            clearTimeout(timeout);
+                            responseReceived = true;
+                            child.kill();
+                            resolve(response);
+                            return;
+                        }
+                    } catch (e) {
+                        // Not JSON, continue
+                    }
+                }
+            }
+        });
+
+        child.stderr.on('data', (data) => {
+            stderr += data.toString();
+        });
+
+        child.on('error', (error) => {
+            clearTimeout(timeout);
+            reject(error);
+        });
+
+        child.on('close', (code) => {
+            clearTimeout(timeout);
+            if (!responseReceived) {
+                reject(new Error(`Server closed with code ${code}. stderr: ${stderr}`));
+            }
+        });
+
+        // Send the request
+        child.stdin.write(JSON.stringify(request) + '\n');
+    });
+}
+
+// Run the tests
+testMCPServer().catch(console.error);

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -2,40 +2,39 @@
  * MCP 関連の型定義
  */
 
+// Zodスキーマからの型定義をインポート
+export type { 
+    SendDiscordEmbedArgs, 
+    SendDiscordEmbedWithFeedbackArgs,
+    FeedbackButton,
+    ColorName
+} from "../validation/schemas";
+
 /**
- * Discord Embed 送信ツールの引数
+ * Discord Bot のレスポンス情報
  */
-export interface SendDiscordEmbedArgs {
-    /** Embed のタイトル */
-    title?: string;
-    /** Embed の説明 */
-    description?: string;
-    /** Embed の色（10進数） */
-    color?: number;
-    /** Embed のフィールド */
-    fields?: Array<{
-        name: string;
-        value: string;
-        inline?: boolean;
-    }>;
+export interface DiscordMessageResponse {
+    /** 送信時刻（ISO 8601形式） */
+    sentAt: string;
+    /** DiscordメッセージID */
+    messageId: string;
+    /** 送信先チャンネルID */
+    channelId: string;
+    /** ステータス */
+    status: "success";
 }
 
 /**
- * Discord フィードバック付き Embed 送信ツールの引数
+ * フィードバック付きDiscord Bot のレスポンス情報
  */
-export interface SendDiscordEmbedWithFeedbackArgs {
-    /** Embed のタイトル */
-    title?: string;
-    /** Embed の説明 */
-    description?: string;
-    /** Embed の色（10進数） */
-    color?: number;
-    /** Embed のフィールド */
-    fields?: Array<{
-        name: string;
-        value: string;
-        inline?: boolean;
-    }>;
-    /** ボタンの上に表示するテキスト */
-    feedbackPrompt?: string;
+export interface DiscordFeedbackResponse extends DiscordMessageResponse {
+    /** フィードバック情報 */
+    feedback: {
+        /** ユーザーの応答 */
+        response: string | "timeout";
+        /** 応答したユーザーID（タイムアウト時は未定義） */
+        userId?: string;
+        /** 応答時間（ミリ秒） */
+        responseTime: number;
+    };
 }

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+/**
+ * CSS基本16色名のスキーマ
+ */
+export const ColorNameSchema = z.enum([
+    "black", "silver", "gray", "white",
+    "maroon", "red", "purple", "fuchsia", 
+    "green", "lime", "olive", "yellow",
+    "navy", "blue", "teal", "aqua"
+]);
+
+export type ColorName = z.infer<typeof ColorNameSchema>;
+
+/**
+ * CSS基本16色名を16進数値に変換するマッピング
+ */
+const COLOR_MAP: Record<ColorName, number> = {
+    black: 0x000000,
+    silver: 0xC0C0C0,
+    gray: 0x808080,
+    white: 0xFFFFFF,
+    maroon: 0x800000,
+    red: 0xFF0000,
+    purple: 0x800080,
+    fuchsia: 0xFF00FF,
+    green: 0x008000,
+    lime: 0x00FF00,
+    olive: 0x808000,
+    yellow: 0xFFFF00,
+    navy: 0x000080,
+    blue: 0x0000FF,
+    teal: 0x008080,
+    aqua: 0x00FFFF
+};
+
+/**
+ * 色名を16進数値に変換
+ * @param colorName CSS基本16色名
+ * @returns Discord用の色値
+ */
+export function colorNameToHex(colorName: ColorName): number {
+    const hexValue = COLOR_MAP[colorName];
+    if (hexValue === undefined) {
+        throw new Error(`Invalid color name: ${colorName}`);
+    }
+    return hexValue;
+}
+
+/**
+ * フィードバックボタンのスキーマ
+ */
+export const FeedbackButtonSchema = z.object({
+    label: z.string().min(1, "ラベルは1文字以上である必要があります").max(80, "ラベルは80文字以下である必要があります"),
+    value: z.string().min(1, "値は1文字以上である必要があります").max(100, "値は100文字以下である必要があります")
+});
+
+export type FeedbackButton = z.infer<typeof FeedbackButtonSchema>;
+
+/**
+ * Embedフィールドのスキーマ
+ */
+export const EmbedFieldSchema = z.object({
+    name: z.string(),
+    value: z.string(),
+    inline: z.boolean().optional()
+});
+
+/**
+ * Discord Embed送信引数のスキーマ
+ */
+export const SendDiscordEmbedArgsSchema = z.object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    color: ColorNameSchema.optional().transform((colorName) => 
+        colorName ? colorNameToHex(colorName) : undefined
+    ),
+    fields: z.array(EmbedFieldSchema).optional()
+});
+
+export type SendDiscordEmbedArgs = z.infer<typeof SendDiscordEmbedArgsSchema>;
+
+/**
+ * Discord フィードバック付きEmbed送信引数のスキーマ
+ */
+export const SendDiscordEmbedWithFeedbackArgsSchema = z.object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    color: ColorNameSchema.optional().transform((colorName) => 
+        colorName ? colorNameToHex(colorName) : undefined
+    ),
+    fields: z.array(EmbedFieldSchema).optional(),
+    feedbackPrompt: z.string().optional(),
+    feedbackButtons: z.array(FeedbackButtonSchema)
+        .min(1, "少なくとも1つのボタンが必要です")
+        .max(5, "最大5つまでのボタンが許可されています")
+        .default([
+            { label: "Yes", value: "yes" },
+            { label: "No", value: "no" }
+        ])
+        .refine((buttons) => {
+            const values = buttons.map(b => b.value);
+            return new Set(values).size === values.length;
+        }, "ボタンの値は重複できません")
+});
+
+export type SendDiscordEmbedWithFeedbackArgs = z.infer<typeof SendDiscordEmbedWithFeedbackArgsSchema>;

--- a/tests/discord/bot.test.ts
+++ b/tests/discord/bot.test.ts
@@ -9,7 +9,9 @@ describe("DiscordBot", () => {
     let mockSend: any;
 
     beforeEach(() => {
-        mockSend = mock(() => Promise.resolve());
+        mockSend = mock(() => Promise.resolve({
+            id: "test-message-123"
+        }));
         mockChannel = {
             isTextBased: () => true,
             send: mockSend

--- a/tests/integration/discord-mcp.test.ts
+++ b/tests/integration/discord-mcp.test.ts
@@ -9,7 +9,9 @@ describe("Discord と MCP の統合テスト", () => {
     let mockSend: any;
 
     beforeEach(() => {
-        mockSend = mock(() => Promise.resolve());
+        mockSend = mock(() => Promise.resolve({
+            id: "test-message-123"
+        }));
         mockChannel = {
             isTextBased: () => true,
             send: mockSend
@@ -80,7 +82,7 @@ describe("Discord と MCP の統合テスト", () => {
             const embedData = {
                 title: "Integration Test",
                 description: "This is an integration test",
-                color: 0x00ff00,
+                color: "lime",
                 fields: [
                     { name: "Status", value: "Success", inline: true },
                     { name: "Environment", value: "Test", inline: true }
@@ -94,7 +96,7 @@ describe("Discord と MCP の統合テスト", () => {
                 embeds: [{
                     title: "Integration Test",
                     description: "This is an integration test",
-                    color: 0x00ff00,
+                    color: 0x00FF00, // lime
                     fields: [
                         { name: "Status", value: "Success", inline: true },
                         { name: "Environment", value: "Test", inline: true }
@@ -102,14 +104,12 @@ describe("Discord と MCP の統合テスト", () => {
                 }]
             });
             
-            expect(result).toEqual({
-                content: [
-                    {
-                        type: "text",
-                        text: "Embed message sent to Discord successfully"
-                    }
-                ]
-            });
+            // レスポンスの内容をパース
+            const parsedResult = JSON.parse(result.content[0].text);
+            expect(parsedResult.status).toBe("success");
+            expect(parsedResult.messageId).toBe("test-message-123");
+            expect(parsedResult.channelId).toBe("test-channel-id");
+            expect(parsedResult.sentAt).toBeDefined();
         });
 
         it("Discord Bot が準備できていない場合、MCP ツールはエラーを返す", async () => {

--- a/tests/mcp/multilingual-feedback.test.ts
+++ b/tests/mcp/multilingual-feedback.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import { MCPServer } from "../../src/mcp/server";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { DiscordBot } from "../../src/discord/bot";
+
+describe("多言語フィードバックボタンテスト", () => {
+    let mcpServer: MCPServer;
+    let mockDiscordBot: DiscordBot;
+    let mockServer: Server;
+
+    beforeEach(() => {
+        mockDiscordBot = {
+            sendMessage: mock(() => Promise.resolve({
+                messageId: "test-message-123",
+                channelId: "test-channel-456",
+                sentAt: "2023-01-01T00:00:00.000Z"
+            })),
+            sendMessageWithFeedback: mock(() => Promise.resolve({
+                response: 'はい',
+                userId: 'test-user-123',
+                responseTime: 1500,
+                messageId: "test-message-123",
+                channelId: "test-channel-456",
+                sentAt: "2023-01-01T00:00:00.000Z"
+            })),
+            getIsReady: mock(() => true),
+            start: mock(() => Promise.resolve()),
+            stop: mock(() => Promise.resolve())
+        } as any;
+
+        mockServer = {
+            setRequestHandler: mock(() => {}),
+            close: mock(() => Promise.resolve()),
+            onerror: undefined,
+            onclose: undefined
+        } as any;
+
+        mcpServer = new MCPServer(mockDiscordBot);
+        (mcpServer as any).server = mockServer;
+    });
+
+    afterEach(() => {
+        if (mcpServer) {
+            mcpServer.stop();
+        }
+    });
+
+    describe("多言語ボタンテスト", () => {
+        it("日本語ボタンでフィードバックを送信する", async () => {
+            const embedData = {
+                title: "アンケート",
+                description: "サービスの満足度をお聞かせください",
+                color: "blue",
+                feedbackButtons: [
+                    { label: "とても満足", value: "とても満足" },
+                    { label: "満足", value: "満足" },
+                    { label: "普通", value: "普通" },
+                    { label: "不満", value: "不満" }
+                ]
+            };
+
+            const result = await (mcpServer as any).callTool("send_discord_embed_with_feedback", embedData);
+
+            expect(mockDiscordBot.sendMessageWithFeedback).toHaveBeenCalledWith(
+                {
+                    embeds: [{
+                        title: "アンケート",
+                        description: "サービスの満足度をお聞かせください",
+                        color: 0x0000FF // blue
+                    }]
+                },
+                "Please select:",
+                [
+                    { label: "とても満足", value: "とても満足" },
+                    { label: "満足", value: "満足" },
+                    { label: "普通", value: "普通" },
+                    { label: "不満", value: "不満" }
+                ],
+                undefined
+            );
+
+            const parsedResult = JSON.parse(result.content[0].text);
+            expect(parsedResult.status).toBe("success");
+            expect(parsedResult.feedback.response).toBe('はい');
+        });
+
+        it("中国語ボタンでフィードバックを送信する", async () => {
+            const embedData = {
+                title: "问卷调查",
+                feedbackButtons: [
+                    { label: "非常好", value: "非常好" },
+                    { label: "好", value: "好" },
+                    { label: "一般", value: "一般" },
+                    { label: "不好", value: "不好" }
+                ]
+            };
+
+            const result = await (mcpServer as any).callTool("send_discord_embed_with_feedback", embedData);
+
+            expect(mockDiscordBot.sendMessageWithFeedback).toHaveBeenCalledWith(
+                {
+                    embeds: [{
+                        title: "问卷调查"
+                    }]
+                },
+                "Please select:",
+                [
+                    { label: "非常好", value: "非常好" },
+                    { label: "好", value: "好" },
+                    { label: "一般", value: "一般" },
+                    { label: "不好", value: "不好" }
+                ],
+                undefined
+            );
+
+            expect(() => result).not.toThrow();
+        });
+
+        it("絵文字を含むボタンでフィードバックを送信する", async () => {
+            const embedData = {
+                title: "Reaction Test",
+                feedbackButtons: [
+                    { label: "😍 Love it!", value: "love" },
+                    { label: "👍 Good", value: "good" },
+                    { label: "😐 Okay", value: "okay" },
+                    { label: "👎 Bad", value: "bad" }
+                ]
+            };
+
+            const result = await (mcpServer as any).callTool("send_discord_embed_with_feedback", embedData);
+
+            expect(mockDiscordBot.sendMessageWithFeedback).toHaveBeenCalledWith(
+                {
+                    embeds: [{
+                        title: "Reaction Test"
+                    }]
+                },
+                "Please select:",
+                [
+                    { label: "😍 Love it!", value: "love" },
+                    { label: "👍 Good", value: "good" },
+                    { label: "😐 Okay", value: "okay" },
+                    { label: "👎 Bad", value: "bad" }
+                ],
+                undefined
+            );
+
+            expect(() => result).not.toThrow();
+        });
+
+        it("多言語混在ボタンでフィードバックを送信する", async () => {
+            const embedData = {
+                title: "International Survey",
+                feedbackButtons: [
+                    { label: "English: Yes", value: "yes_en" },
+                    { label: "日本語: はい", value: "はい_ja" },
+                    { label: "Español: Sí", value: "si_es" },
+                    { label: "Русский: Да", value: "да_ru" }
+                ]
+            };
+
+            const result = await (mcpServer as any).callTool("send_discord_embed_with_feedback", embedData);
+
+            expect(mockDiscordBot.sendMessageWithFeedback).toHaveBeenCalledWith(
+                {
+                    embeds: [{
+                        title: "International Survey"
+                    }]
+                },
+                "Please select:",
+                [
+                    { label: "English: Yes", value: "yes_en" },
+                    { label: "日本語: はい", value: "はい_ja" },
+                    { label: "Español: Sí", value: "si_es" },
+                    { label: "Русский: Да", value: "да_ru" }
+                ],
+                undefined
+            );
+
+            expect(() => result).not.toThrow();
+        });
+    });
+});

--- a/tests/validation/schemas.test.ts
+++ b/tests/validation/schemas.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "bun:test";
+import { 
+    ColorNameSchema, 
+    FeedbackButtonSchema, 
+    SendDiscordEmbedArgsSchema,
+    SendDiscordEmbedWithFeedbackArgsSchema,
+    colorNameToHex 
+} from "../../src/validation/schemas";
+
+describe("ColorNameSchema", () => {
+    const validColors = [
+        "black", "silver", "gray", "white", "maroon", "red", "purple", "fuchsia",
+        "green", "lime", "olive", "yellow", "navy", "blue", "teal", "aqua"
+    ];
+
+    const invalidColors = [
+        "orange", "pink", "brown", "darkgreen", "lightblue", "", "RED", "Blue", "123"
+    ];
+
+    describe("有効な色名", () => {
+        validColors.forEach(color => {
+            it(`${color} を受け入れる`, () => {
+                expect(() => ColorNameSchema.parse(color)).not.toThrow();
+            });
+        });
+    });
+
+    describe("無効な色名", () => {
+        invalidColors.forEach(color => {
+            it(`${color} を拒否する`, () => {
+                expect(() => ColorNameSchema.parse(color)).toThrow();
+            });
+        });
+    });
+});
+
+describe("colorNameToHex", () => {
+    it("CSS基本16色を正しい16進値に変換する", () => {
+        expect(colorNameToHex("black")).toBe(0x000000);
+        expect(colorNameToHex("white")).toBe(0xFFFFFF);
+        expect(colorNameToHex("red")).toBe(0xFF0000);
+        expect(colorNameToHex("green")).toBe(0x008000);
+        expect(colorNameToHex("blue")).toBe(0x0000FF);
+        expect(colorNameToHex("yellow")).toBe(0xFFFF00);
+        expect(colorNameToHex("aqua")).toBe(0x00FFFF);
+        expect(colorNameToHex("fuchsia")).toBe(0xFF00FF);
+        expect(colorNameToHex("lime")).toBe(0x00FF00);
+        expect(colorNameToHex("maroon")).toBe(0x800000);
+        expect(colorNameToHex("navy")).toBe(0x000080);
+        expect(colorNameToHex("olive")).toBe(0x808000);
+        expect(colorNameToHex("purple")).toBe(0x800080);
+        expect(colorNameToHex("silver")).toBe(0xC0C0C0);
+        expect(colorNameToHex("teal")).toBe(0x008080);
+        expect(colorNameToHex("gray")).toBe(0x808080);
+    });
+
+    it("無効な色名に対してエラーを投げる", () => {
+        expect(() => colorNameToHex("orange" as any)).toThrow();
+        expect(() => colorNameToHex("" as any)).toThrow();
+    });
+});
+
+describe("FeedbackButtonSchema", () => {
+    describe("有効なボタン", () => {
+        it("基本的なボタンを受け入れる", () => {
+            const validButton = { label: "Yes", value: "yes" };
+            expect(() => FeedbackButtonSchema.parse(validButton)).not.toThrow();
+        });
+
+        it("最大長のラベルと値を受け入れる", () => {
+            const validButton = {
+                label: "A".repeat(80),
+                value: "a".repeat(100)
+            };
+            expect(() => FeedbackButtonSchema.parse(validButton)).not.toThrow();
+        });
+
+        it("英数字とアンダースコアの値を受け入れる", () => {
+            const validButton = { label: "Option", value: "option_1_test" };
+            expect(() => FeedbackButtonSchema.parse(validButton)).not.toThrow();
+        });
+
+        it("日本語などの多言語文字を受け入れる", () => {
+            const validButtons = [
+                { label: "はい", value: "はい" },
+                { label: "Sí", value: "si" },
+                { label: "Да", value: "да" },
+                { label: "是", value: "是" }
+            ];
+            
+            validButtons.forEach(button => {
+                expect(() => FeedbackButtonSchema.parse(button)).not.toThrow();
+            });
+        });
+    });
+
+    describe("無効なボタン", () => {
+        it("空のラベルを拒否する", () => {
+            const invalidButton = { label: "", value: "yes" };
+            expect(() => FeedbackButtonSchema.parse(invalidButton)).toThrow();
+        });
+
+        it("長すぎるラベルを拒否する", () => {
+            const invalidButton = { label: "A".repeat(81), value: "yes" };
+            expect(() => FeedbackButtonSchema.parse(invalidButton)).toThrow();
+        });
+
+        it("空の値を拒否する", () => {
+            const invalidButton = { label: "Yes", value: "" };
+            expect(() => FeedbackButtonSchema.parse(invalidButton)).toThrow();
+        });
+
+        it("長すぎる値を拒否する", () => {
+            const invalidButton = { label: "Yes", value: "a".repeat(101) };
+            expect(() => FeedbackButtonSchema.parse(invalidButton)).toThrow();
+        });
+
+    });
+});
+
+describe("SendDiscordEmbedArgsSchema", () => {
+    describe("有効な引数", () => {
+        it("色名を含む完全なEmbedを受け入れる", () => {
+            const validArgs = {
+                title: "Test Title",
+                description: "Test Description",
+                color: "red",
+                fields: [
+                    { name: "Field 1", value: "Value 1", inline: true },
+                    { name: "Field 2", value: "Value 2" }
+                ]
+            };
+            
+            const result = SendDiscordEmbedArgsSchema.parse(validArgs);
+            expect(result.color).toBe(0xFF0000); // red
+        });
+
+        it("最小限のEmbedを受け入れる", () => {
+            const validArgs = {};
+            expect(() => SendDiscordEmbedArgsSchema.parse(validArgs)).not.toThrow();
+        });
+
+        it("フィールドなしのEmbedを受け入れる", () => {
+            const validArgs = {
+                title: "Title Only",
+                color: "blue"
+            };
+            
+            const result = SendDiscordEmbedArgsSchema.parse(validArgs);
+            expect(result.color).toBe(0x0000FF); // blue
+        });
+    });
+
+    describe("無効な引数", () => {
+        it("無効な色名を拒否する", () => {
+            const invalidArgs = {
+                title: "Test",
+                color: "orange"
+            };
+            expect(() => SendDiscordEmbedArgsSchema.parse(invalidArgs)).toThrow();
+        });
+
+        it("無効なフィールド構造を拒否する", () => {
+            const invalidArgs = {
+                title: "Test",
+                fields: [
+                    { name: "Field 1" } // valueが欠落
+                ]
+            };
+            expect(() => SendDiscordEmbedArgsSchema.parse(invalidArgs)).toThrow();
+        });
+    });
+});
+
+describe("SendDiscordEmbedWithFeedbackArgsSchema", () => {
+    describe("有効な引数", () => {
+        it("デフォルトボタンを使用", () => {
+            const validArgs = {
+                title: "Feedback Test",
+                feedbackPrompt: "Please choose:"
+            };
+            
+            const result = SendDiscordEmbedWithFeedbackArgsSchema.parse(validArgs);
+            expect(result.feedbackButtons).toEqual([
+                { label: "Yes", value: "yes" },
+                { label: "No", value: "no" }
+            ]);
+        });
+
+        it("カスタムボタンを受け入れる", () => {
+            const validArgs = {
+                title: "Custom Feedback",
+                feedbackButtons: [
+                    { label: "Agree", value: "agree" },
+                    { label: "Disagree", value: "disagree" },
+                    { label: "Neutral", value: "neutral" }
+                ]
+            };
+            
+            const result = SendDiscordEmbedWithFeedbackArgsSchema.parse(validArgs);
+            expect(result.feedbackButtons).toHaveLength(3);
+        });
+
+        it("最大5つのボタンを受け入れる", () => {
+            const validArgs = {
+                title: "Max Buttons",
+                feedbackButtons: [
+                    { label: "1", value: "one" },
+                    { label: "2", value: "two" },
+                    { label: "3", value: "three" },
+                    { label: "4", value: "four" },
+                    { label: "5", value: "five" }
+                ]
+            };
+            
+            expect(() => SendDiscordEmbedWithFeedbackArgsSchema.parse(validArgs)).not.toThrow();
+        });
+    });
+
+    describe("無効な引数", () => {
+        it("6つ以上のボタンを拒否する", () => {
+            const invalidArgs = {
+                title: "Too Many Buttons",
+                feedbackButtons: [
+                    { label: "1", value: "one" },
+                    { label: "2", value: "two" },
+                    { label: "3", value: "three" },
+                    { label: "4", value: "four" },
+                    { label: "5", value: "five" },
+                    { label: "6", value: "six" }
+                ]
+            };
+            
+            expect(() => SendDiscordEmbedWithFeedbackArgsSchema.parse(invalidArgs)).toThrow();
+        });
+
+        it("空のボタン配列を拒否する", () => {
+            const invalidArgs = {
+                title: "No Buttons",
+                feedbackButtons: []
+            };
+            
+            expect(() => SendDiscordEmbedWithFeedbackArgsSchema.parse(invalidArgs)).toThrow();
+        });
+
+        it("重複する値を拒否する", () => {
+            const invalidArgs = {
+                title: "Duplicate Values",
+                feedbackButtons: [
+                    { label: "Yes", value: "yes" },
+                    { label: "Confirm", value: "yes" }
+                ]
+            };
+            
+            expect(() => SendDiscordEmbedWithFeedbackArgsSchema.parse(invalidArgs)).toThrow();
+        });
+    });
+});


### PR DESCRIPTION
Submitted by Claude Code 🛠️
---

## 📒概要

Discord Interface MCPの3つの主要な改善提案を実装：
1. CSS基本16色名の採用（LLMにとってより直感的）
2. 拡張レスポンス情報（タイムスタンプ、メッセージID等）
3. カスタムフィードバックボタン（1-5個の柔軟な設定）

## 🎯変更目的

- **LLMの使いやすさ向上**: 10進数色値からCSS色名への変更
- **デバッグ効率向上**: 詳細なレスポンス情報の提供
- **国際化対応**: 多言語フィードバックボタンのサポート
- **型安全性強化**: [Zod](https://zod.dev/)による実行時バリデーション

## 📝変更内容

### 🎨 CSS基本16色の採用
- `src/validation/schemas.ts` - CSS基本16色のZodスキーマ定義
- 色名→16進数値の自動変換機能
- 無効な色名の厳密なバリデーション

### 🔘 カスタムフィードバックボタン
- 固定Yes/Noから1-5個のカスタムボタンに拡張
- Unicode対応（日本語、絵文字等）
- ラベル（1-80文字）、値（1-100文字）の制限

### 📊 拡張レスポンス情報
- メッセージID、チャンネルID、送信時刻
- フィードバック応答時間とユーザーID
- 構造化されたJSONレスポンス

### 🛡️ セキュリティ・品質向上
- Zodスキーマによる実行時型チェック
- Test-Driven Development（TDD）
- 77個のテストケースで包括的カバレッジ

### ✨ UIの改善
- フィードバック成功: `✅ You Selected: **value**`
- 期限切れ: `❌ This feedback session has expired.`

## ✅テスト結果

```bash
bun test
✓ 77 tests passed
```

- `tests/validation/schemas.test.ts` - Zodスキーマの46テスト
- `tests/mcp/multilingual-feedback.test.ts` - 多言語対応の4テスト
- 既存テストの更新と統合テスト

## 🔗関連情報

- [CSS Basic 16 Colors](https://www.w3.org/TR/css-color-3/#x11-color)
- [Zod Schema Validation](https://zod.dev/)
- [Discord.js ButtonBuilder](https://discord.js.org/#/docs/discord.js/main/class/ButtonBuilder)
- [Model Context Protocol](https://modelcontextprotocol.io/)

🤖 Generated with [Claude Code](https://claude.ai/code)