### PR TITLE
fix: DXTパッケージ名を修正してGitHub Release作成を有効化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
 
             - name: Install DXT CLI
               if: steps.version-check.outputs.should_publish == 'true'
-              run: npm install -g @anthropic/dxt
+              run: npm install -g @anthropic-ai/dxt
 
             - name: Build DXT package
               if: steps.version-check.outputs.should_publish == 'true'


### PR DESCRIPTION
Submitted by Claude Code 🛠️
---

## 📒概要

v2.1.0リリース時にGitHub Release作成が失敗した問題を修正します。

## 🎯変更目的

DXTパッケージ名の誤りにより、GitHub ActionsでのDXTパッケージ作成とGitHub Release作成が失敗していた問題を解決するため。

## 📝変更内容

- `.github/workflows/publish.yml`のDXTパッケージ名を修正
  - `@anthropic/dxt` → `@anthropic-ai/dxt`

## ✅テスト結果

ローカルでDXTパッケージ化を実行し、正常に動作することを確認：
- `npm install -g @anthropic-ai/dxt` - 成功
- `dxt pack` - `discord-interface-mcp.dxt`ファイルが正常に生成

## 🔗関連情報

- v2.1.0リリース時の失敗ログ: [GitHub Actions Run](https://github.com/RateteDev/discord-interface-mcp/actions/runs/16584351548)
- エラー: `npm error 404 Not Found - GET https://registry.npmjs.org/@anthropic%2fdxt`
- 正しいパッケージ名: `@anthropic-ai/dxt`

このPRがマージされると、次回のバージョンアップ時にGitHub Releaseが正常に作成されます。