### PR TITLE
fix: CIワークフローでmainブランチの重複実行を防止

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: CI
 on:
     push:
         branches:
-            - main
             - develop
     pull_request:
         branches:


### PR DESCRIPTION
## 🐛 問題

前回のワークフロー改善により、mainブランチへのpush時にCIとCDの両方が実行される重複問題が発生していました。

## 🔧 修正内容

### 修正前の動作
- **PR作成時**: CIワークフロー実行 ✅
- **mainマージ時**: CI + CDワークフロー両方実行 ❌（重複）

### 修正後の動作  
- **PR作成時**: CIワークフローのみ実行 ✅
- **mainマージ時**: CDワークフローのみ実行 ✅
- **developプッシュ時**: CIワークフローのみ実行 ✅

## 📝 変更詳細

CIワークフロー (`.github/workflows/ci.yml`) のトリガー条件を修正：

```yaml
# 修正前
on:
    push:
        branches:
            - main      # ← 削除
            - develop
    pull_request:
        branches:
            - main
            - develop
```

```yaml  
# 修正後
on:
    push:
        branches:
            - develop   # developのみ
    pull_request:
        branches:
            - main
            - develop
```

## ✅ 効果

- GitHub Actions の実行時間とリソースの無駄を削減
- ワークフローの責任分離を明確化
- デプロイ処理の重複実行リスクを排除

🤖 Generated with [Claude Code](https://claude.ai/code)